### PR TITLE
Improve documents

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -13,9 +13,10 @@ pub mod preprocess;
 pub mod sallen_key;
 pub mod svf;
 
-/// cheap tanh to make the filter faster.
-// from a quick look it looks extremely good, max error of ~0.0002 or .02%
-// the error of 1 - tanh_levien^2 as the derivative is about .06%
+/// Cheap tanh to make the filter faster.
+///
+/// From a quick look it looks extremely good, max error of ~0.0002 or .02%  
+/// The error of 1 - tanh_levien^2 as the derivative is about .06%
 #[inline]
 pub fn tanh_levien(x: f32x4) -> f32x4 {
     let x2 = x * x;
@@ -119,7 +120,8 @@ impl LadderFilter {
 
         self.vout[self.params.slope.value() as usize]
     }
-    // linear version without distortion
+
+    /// Linear version without distortion.
     pub fn run_filter_linear(&mut self, input: f32x4) -> f32x4 {
         // denominators of solutions of individual stages. Simplifies the math a bit
         let g = f32x4::splat(self.params.g.get());
@@ -211,7 +213,8 @@ impl LadderFilter {
         self.vout = v_est;
         self.vout[self.params.slope.value() as usize]
     }
-    // performs a complete filter process (newton-raphson method)
+
+    /// Performs a complete filter process (newton-raphson method).
     pub fn tick_newton(&mut self, input: f32x4) -> f32x4 {
         // perform filter process
         let out = self.run_filter_newton(input * f32x4::splat(self.params.drive.value()));
@@ -219,7 +222,8 @@ impl LadderFilter {
         self.update_state();
         out * f32x4::splat((1. + self.params.k_ladder.get()) / (self.params.drive.value() * 0.5))
     }
-    // performs a complete filter process (newton-raphson method)
+
+    /// Performs a complete filter process (newton-raphson method).
     pub fn tick_pivotal(&mut self, input: f32x4) -> f32x4 {
         // perform filter process
         let out = self.run_filter_pivotal(input * f32x4::splat(self.params.drive.value()));
@@ -227,7 +231,8 @@ impl LadderFilter {
         self.update_state();
         out
     }
-    // performs a complete filter process (newton-raphson method)
+
+    /// Performs a complete filter process (newton-raphson method).
     pub fn tick_linear(&mut self, input: f32x4) -> f32x4 {
         // perform filter process
         // let out = self.run_filter_linear(input * f32x4::splat(self.params.drive.value));

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -141,6 +141,8 @@ impl LadderFilter {
         self.vout[2] = g0 * (g * self.vout[1] + self.s[2]);
         self.vout[self.params.slope.value() as usize]
     }
+
+    /// Newton-raphson method version.
     pub fn run_filter_newton(&mut self, input: f32x4) -> f32x4 {
         // dbg!(input);
         // ---------- setup ----------

--- a/src/filter/sallen_key.rs
+++ b/src/filter/sallen_key.rs
@@ -341,7 +341,8 @@ impl SallenKeyCore {
 const N_P2: usize = 2;
 const N_N2: usize = 3;
 const P_LEN2: usize = 6;
-/// this does the same as `SallenKeyCore`, but with most equations simplified to make it faster
+
+/// This does the same as `SallenKeyCore`, but with most equations simplified to make it faster.
 pub struct SallenKeyCoreFast {
     pub params: Arc<FilterParams>,
     pub vout: [f32; N_OUTS],


### PR DESCRIPTION
Some function comments were indicated by normal comments ("//") and were not displayed after cargo doc.
Changed to doc comments("///").
Also, added a period at the end of the line and capitalized the first letter. This is because most crates use this format for their documents.

Also added doc comments to run_filter_newton(). There may be more appropriate wording.