### PR TITLE
Fix an error of SIMD module

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,6 +1,6 @@
 #![feature(portable_simd)]
 #![allow(dead_code)]
-use core_simd::f32x4;
+use core_simd::simd::f32x4;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::sync::Arc;
 use va_filter::filter::svf::SvfCoreFast;


### PR DESCRIPTION
Fixed an error in the SIMD module that was preventing benchmarking.